### PR TITLE
added -p command line option to print path of included files

### DIFF
--- a/src/avra.c
+++ b/src/avra.c
@@ -50,6 +50,7 @@ const char *usage =
     "            [--define <symbol>[=<value>]]\n"
     "            [-I <dir>] [--listmac]\n"
     "            [--max_errors <number>] [--devices] [--version]\n"
+    "            [-p] print full path of included files on pass 2\n"
     "            [-O e|w|i]\n"
     "            [-h] [--help] general help\n"
     "            <file to assemble>\n"
@@ -63,6 +64,7 @@ const char *usage =
     "                      (default: 10)\n"
     "   --devices        : List out supported devices.\n"
     "   --version        : Version information.\n"
+    "   --print-inc      : print full path of included files on pass 2\n"
     "   -O e|w|i         : Issue error/warning/ignore overlapping code.\n"
     "   --help, -h       : This help text.\n";
 
@@ -108,6 +110,7 @@ main(int argc, const char *argv[])
 		define_arg(args, ARG_DEVICES,     ARGTYPE_BOOLEAN,              0,  "devices",     NULL, NULL);
 		define_arg(args, ARG_VER,         ARGTYPE_BOOLEAN,              0,  "version",     NULL, NULL);
 		define_arg(args, ARG_HELP,        ARGTYPE_BOOLEAN,             'h', "help",        NULL, NULL);
+		define_arg(args, ARG_PRINTINC,    ARGTYPE_BOOLEAN,             'p', "print-inc",   NULL, NULL);
 		define_arg(args, ARG_WRAP,        ARGTYPE_BOOLEAN,             'w', "wrap",        NULL, NULL);	/* Not implemented ? B.A. */
 		define_arg(args, ARG_WARNINGS,    ARGTYPE_STRING_MULTISINGLE,  'W', "warn",        NULL, NULL);
 		define_arg(args, ARG_FILEFORMAT,  ARGTYPE_CHAR_ATTACHED,       'f', "filetype",    "0",	 NULL);	/* Not implemented ? B.A. */
@@ -381,6 +384,7 @@ init_prog_info(struct prog_info *pi, struct args *args)
 
 	pi->max_errors = GET_ARG_I(args, ARG_MAX_ERRORS);
 	pi->pass=PASS_1;
+    pi->printinc = GET_ARG_I(args, ARG_PRINTINC);
 	pi->time=time(NULL);
 	pi->effective_overlap = GET_ARG_I(pi->args, ARG_OVERLAP);
 	pi->segment_overlap = SEG_DONT_OVERLAP;

--- a/src/avra.h
+++ b/src/avra.h
@@ -59,6 +59,7 @@ enum {
 	ARG_DEVICES,		/* --devices               */
 	ARG_VER,		/* --version               */
 	ARG_HELP,		/* --help, -h              */
+	ARG_PRINTINC,		/* --print-inc, -p         */
 	ARG_WRAP,		/* --wrap                  */
 	ARG_WARNINGS,		/* --warn, -W              */
 	ARG_FILEFORMAT,		/* --filetype              */
@@ -188,6 +189,7 @@ struct prog_info {
 	/* Warning additions */
 	int NoRegDef;
 	int pass;
+	int printinc;
 };
 
 struct file_info {

--- a/src/parser.c
+++ b/src/parser.c
@@ -140,6 +140,12 @@ parse_file(struct prog_info *pi, const char *filename)
 #if debug == 1
 	printf("Opening %s\n",filename);
 #endif
+
+    if( (pi->pass==PASS_2) && (pi->printinc) )
+      {
+        printf("Including %s\n",filename);
+      }
+    
 	if ((fi->fp = fopen(filename, "r"))==NULL) {
 		perror(filename);
 		free(fi);


### PR DESCRIPTION
I don't think avra prints the full path of an included file either to the list file or to stdio. There is a potential use for this in the AmForth build, so I have add a few lines of code to provide a command line option to print the full path of an included file to stdio. 